### PR TITLE
Funtion for triangle area calculation in dagmc_stats.py file and its partial test

### DIFF
--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -1,7 +1,6 @@
 # set the path to find the current installation of pyMOAB
 import sys
 import numpy as np
-import math
 
 sys.path.append(
     '/opt/tljh/user/lib/moab/lib/python3.6/site-packages/pymoab-5.1.0-py3.6-linux-x86_64.egg')
@@ -207,7 +206,7 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
 def get_area_triangle(my_core, meshset):
 	
 	"""
-    Gets the triangle area (according to the equation: sqrt(s(s - a)(s - b)(s - c)), where s = a + b + c)
+    Gets the triangle area (according to the equation: sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2)
     
     inputs
     ------
@@ -238,8 +237,9 @@ def get_area_triangle(my_core, meshset):
             # The indices of coord_list includes the "-2" because this way each side will be matched up with both
             # other sides of the triangle (IDs: (Side 0, Side 1), (Side 1, Side 2), (Side 2, Side 0))
 
-        s = math.sqrt(sum(side_lengths) * np.prod(sum(side_lengths) - side_lengths))
+		s = sum(side_lengths)/2
+        s = np.sqrt(s * np.prod(s - side_lengths))
         area.append(s)
-        # sqrt(s(s - a)(s - b)(s - c)), where s = a + b + c
+        # sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2
 
     return area

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -155,7 +155,6 @@ def get_surfaces_per_volume(my_core, entityset_ranges):
 
 
 def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
-
     """
     Gets the triangle aspect ratio (according to the equation: (abc)/(8(s-a)(s-b)(s-c)), where s = .5(a+b+c).)
     
@@ -203,9 +202,8 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
 
     return t_a_r
 
-def get_area_triangle(my_core, meshset):
-	
-	"""
+def get_area_triangle(my_core, meshset):	
+    """
     Gets the triangle area (according to the equation: sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2)
     
     inputs
@@ -237,7 +235,7 @@ def get_area_triangle(my_core, meshset):
             # The indices of coord_list includes the "-2" because this way each side will be matched up with both
             # other sides of the triangle (IDs: (Side 0, Side 1), (Side 1, Side 2), (Side 2, Side 0))
 
-		s = sum(side_lengths)/2
+	s = sum(side_lengths)/2
         s = np.sqrt(s * np.prod(s - side_lengths))
         area.append(s)
         # sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -201,3 +201,29 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
         t_a_r.append(top/bottom)
 
     return t_a_r
+
+def get_area_triangle(my_core, meshset):
+    area = []
+    tris = my_core.get_entities_by_type(meshset, types.MBTRI)
+
+    for triangle in tris:
+        side_lengths = []
+        s = 0
+        coord_list = []
+
+        verts = list(my_core.get_adjacencies(triangle, 0))
+
+        for vert in verts:
+            coords = my_core.get_coords(vert)
+            coord_list.append(coords)
+
+        for side in range(3):
+            side_lengths.append(np.linalg.norm(coord_list[side] - coord_list[side - 2]))
+            # The indices of coord_list includes the "-2" because this way each side will be matched up with both
+            # other sides of the triangle (IDs: (Side 0, Side 1), (Side 1, Side 2), (Side 2, Side 0))
+
+        s = math.sqrt(sum(side_lengths) * np.prod(sum(side_lengths) - side_lengths))
+        area.append(s)
+        # sqrt(s(s - a)(s - b)(s - c)), where s = a + b + c
+
+    return area

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -1,6 +1,8 @@
 # set the path to find the current installation of pyMOAB
 import sys
 import numpy as np
+import math
+
 sys.path.append(
     '/opt/tljh/user/lib/moab/lib/python3.6/site-packages/pymoab-5.1.0-py3.6-linux-x86_64.egg')
 from pymoab.rng import Range

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -179,7 +179,7 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
 
     t_a_r = []
 
-    for triangle in tris:
+    for tri in tris:
         side_lengths = []
         s = 0
         coord_list = []
@@ -219,7 +219,7 @@ def get_area_triangle(my_core, meshset):
     area = []
     tris = my_core.get_entities_by_type(meshset, types.MBTRI)
 
-    for triangle in tris:
+    for tri in tris:
         side_lengths = []
         s = 0
         coord_list = []
@@ -235,9 +235,9 @@ def get_area_triangle(my_core, meshset):
             # The indices of coord_list includes the "-2" because this way each side will be matched up with both
             # other sides of the triangle (IDs: (Side 0, Side 1), (Side 1, Side 2), (Side 2, Side 0))
 
+        # sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2
         s = sum(side_lengths)/2
         s = np.sqrt(s * np.prod(s - side_lengths))
         area.append(s)
-        # sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2
 
     return area

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -205,6 +205,20 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
     return t_a_r
 
 def get_area_triangle(my_core, meshset):
+	
+	"""
+    Gets the triangle area (according to the equation: sqrt(s(s - a)(s - b)(s - c)), where s = a + b + c)
+    
+    inputs
+    ------
+    my_core : a MOAB Core instance
+    meshset : a meshset containing a certain part of the mesh
+    
+    outputs
+    -------
+    area : (list) the triangle areas for all triangles in the meshset
+    """
+    
     area = []
     tris = my_core.get_entities_by_type(meshset, types.MBTRI)
 

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -235,7 +235,7 @@ def get_area_triangle(my_core, meshset):
             # The indices of coord_list includes the "-2" because this way each side will be matched up with both
             # other sides of the triangle (IDs: (Side 0, Side 1), (Side 1, Side 2), (Side 2, Side 0))
 
-	s = sum(side_lengths)/2
+        s = sum(side_lengths)/2
         s = np.sqrt(s * np.prod(s - side_lengths))
         area.append(s)
         # sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -156,7 +156,10 @@ def get_surfaces_per_volume(my_core, entityset_ranges):
 
 def get_tris(my_core, meshset, geom_dim):
     """
-    get triangles
+    get triangles of a volume if geom_dim is 3
+    get triangles of a surface if geom_dim is 2
+    else get all the triangles
+
     inputs
     ------
     my_core : a MOAB core instance
@@ -165,18 +168,21 @@ def get_tris(my_core, meshset, geom_dim):
 
     outputs
     -------
-    tris : (list)triangles
+    tris : (list)triangle entities
     """
+    # get triangles of a volume
     if my_core.tag_get_data(geom_dim, meshset)[0][0] == 3:
         entities = my_core.create_meshset()
         for surface in my_core.get_child_meshsets(meshset):
             my_core.add_entities(entities, my_core.get_entities_by_type(surface, types.MBTRI))
         tris = my_core.get_entities_by_type(entities, types.MBTRI)
+    # get triangles of a surface
     elif my_core.tag_get_data(geom_dim, meshset)[0][0] == 2:
         entities = my_core.create_meshset()
         my_core.add_entities(entities, my_core.get_entities_by_type(meshset, types.MBTRI))
         tris = my_core.get_entities_by_type(entities, types.MBTRI)
     else:
+    # get all the triangles
         tris = my_core.get_entities_by_type(meshset, types.MBTRI)
     return tris
 
@@ -184,10 +190,11 @@ def get_tris(my_core, meshset, geom_dim):
 def get_tri_side_length(my_core, tri):
     """
     get side lengths of triangle
+
     inputs
     ------
     my_core : a MOAB Core instance
-    tri : triangle
+    tri : triangle entity
 
     outputs
     -------
@@ -236,10 +243,11 @@ def get_triangle_aspect_ratio(my_core, meshset, geom_dim):
 
     return t_a_r
 
+
 def get_area_triangle(my_core, meshset, geom_dim):	
     """
     Gets the triangle area (according to the equation: sqrt(s(s - a)(s - b)(s - c)), where s = (a + b + c)/2)
-    
+
     inputs
     ------
     my_core : a MOAB Core instance

--- a/dagmc_stats.py
+++ b/dagmc_stats.py
@@ -172,6 +172,10 @@ def get_tris(my_core, meshset, geom_dim):
         for surface in my_core.get_child_meshsets(meshset):
             my_core.add_entities(entities, my_core.get_entities_by_type(surface, types.MBTRI))
         tris = my_core.get_entities_by_type(entities, types.MBTRI)
+    elif my_core.tag_get_data(geom_dim, meshset)[0][0] == 2:
+        entities = my_core.create_meshset()
+        my_core.add_entities(entities, my_core.get_entities_by_type(meshset, types.MBTRI))
+        tris = my_core.get_entities_by_type(entities, types.MBTRI)
     else:
         tris = my_core.get_entities_by_type(meshset, types.MBTRI)
     return tris

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -222,7 +222,7 @@ def main():
                        'TPS':args.tps, 'TAR':args.tar, 'AT': args.at, 'TPS_data':args.tps_data, 'SPV_data':args.spv_data} 
     if not(True in display_options.values()):
         display_options = {'NR':True, 'ER':True, 'SPV':True, 'TPV':True, 'TPS':True,
-			   'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
+                           'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
     my_core = core.Core() #initiates core
     my_core.load_file(input_file) #loads the file
     root_set = my_core.get_root_set() #dumps all entities into the meshset to be redistributed to other meshsets

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -54,6 +54,10 @@ def report_stats(stats, data, verbose, display_options):
             for statistic, value in stats['T_A_R'].items():
                 print("The {} Triangle Aspect Ratio in this model is {}.".format(
                     statistic, value))
+        if diaplay_options['AT']:
+            for statistic, value in stats['A_T'].items():
+                print("The {} Triangle Area in this model is {}.".format(
+                    statistic, value))
     else: #or, print with minimal words
         if display_options['NR']:
             for nr, size in stats['native_ranges'].items():
@@ -76,6 +80,10 @@ def report_stats(stats, data, verbose, display_options):
         if display_options['TAR']:
             print("Triangle Aspect Ratio:")
             for statistic, value in stats['T_A_R'].items():
+                print("{} : {}".format(statistic, value))
+        if diaplay_options['AT']:
+            print("Triangle Area:")
+            for statistic, value in stats['A_T'].items():
                 print("{} : {}".format(statistic, value))
 
     if display_options['SPV_data']:
@@ -163,7 +171,12 @@ def collect_statistics(my_core, root_set, tar_meshset, display_options):
         data[tar_key] = dagmc_stats.get_triangle_aspect_ratio(
                                     my_core, tar_meshset, dagmc_tags['geom_dim'])
         stats[tar_key] = get_stats(data[tar_key])
-        
+   
+    if display_options['AT_data']:
+        at_key = 'A_T'
+        data[at_key] = dagmc_stats.get_area_triangle(my_core, tar_meshset)
+        stats[at_key] = get_stats(data[at_key])
+
     if display_options['SPV_data']:
         data['SPV_Entity'] = entity_specific_stats.get_spv_data(my_core,
                                                                 entityset_ranges, dagmc_tags['global_id'])
@@ -197,6 +210,8 @@ def main():
                         help = "display triangle aspect ratio stats")
     parser.add_argument("--tar_meshset", type = np.uint64, help =
                         "meshset for triangle aspect ratio stats")
+    parser.add_argument("--at", action="store_true", 
+                        help="display triangle area stats")
     args = parser.parse_args() 
 
     input_file = args.filename
@@ -204,10 +219,10 @@ def main():
     tps_data = args.tps_data
     spv_data = args.spv_data
     display_options = {'NR':args.nr, 'ER':args.er, 'SPV':args.spv, 'TPV':args.tpv,
-                       'TPS':args.tps, 'TAR':args.tar, 'TPS_data':args.tps_data, 'SPV_data':args.spv_data} 
+                       'TPS':args.tps, 'TAR':args.tar, 'AT': args.at, 'TPS_data':args.tps_data, 'SPV_data':args.spv_data} 
     if not(True in display_options.values()):
         display_options = {'NR':True, 'ER':True, 'SPV':True, 'TPV':True, 'TPS':True,
-                           'TAR':True, 'TPS_data':False, 'SPV_data':False}
+                'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
     my_core = core.Core() #initiates core
     my_core.load_file(input_file) #loads the file
     root_set = my_core.get_root_set() #dumps all entities into the meshset to be redistributed to other meshsets

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -222,7 +222,7 @@ def main():
                        'TPS':args.tps, 'TAR':args.tar, 'AT': args.at, 'TPS_data':args.tps_data, 'SPV_data':args.spv_data} 
     if not(True in display_options.values()):
         display_options = {'NR':True, 'ER':True, 'SPV':True, 'TPV':True, 'TPS':True,
-						   'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
+			   'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
     my_core = core.Core() #initiates core
     my_core.load_file(input_file) #loads the file
     root_set = my_core.get_root_set() #dumps all entities into the meshset to be redistributed to other meshsets

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -222,7 +222,7 @@ def main():
                        'TPS':args.tps, 'TAR':args.tar, 'AT': args.at, 'TPS_data':args.tps_data, 'SPV_data':args.spv_data} 
     if not(True in display_options.values()):
         display_options = {'NR':True, 'ER':True, 'SPV':True, 'TPV':True, 'TPS':True,
-                'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
+						   'TAR':True, 'AT':True, 'TPS_data':False, 'SPV_data':False}
     my_core = core.Core() #initiates core
     my_core.load_file(input_file) #loads the file
     root_set = my_core.get_root_set() #dumps all entities into the meshset to be redistributed to other meshsets

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -54,7 +54,7 @@ def report_stats(stats, data, verbose, display_options):
             for statistic, value in stats['T_A_R'].items():
                 print("The {} Triangle Aspect Ratio in this model is {}.".format(
                     statistic, value))
-        if diaplay_options['AT']:
+        if display_options['AT']:
             for statistic, value in stats['A_T'].items():
                 print("The {} Triangle Area in this model is {}.".format(
                     statistic, value))
@@ -81,7 +81,7 @@ def report_stats(stats, data, verbose, display_options):
             print("Triangle Aspect Ratio:")
             for statistic, value in stats['T_A_R'].items():
                 print("{} : {}".format(statistic, value))
-        if diaplay_options['AT']:
+        if display_options['AT']:
             print("Triangle Area:")
             for statistic, value in stats['A_T'].items():
                 print("{} : {}".format(statistic, value))
@@ -172,7 +172,7 @@ def collect_statistics(my_core, root_set, tar_meshset, display_options):
                                     my_core, tar_meshset, dagmc_tags['geom_dim'])
         stats[tar_key] = get_stats(data[tar_key])
    
-    if display_options['AT_data']:
+    if display_options['AT']:
         at_key = 'A_T'
         data[at_key] = dagmc_stats.get_area_triangle(my_core, tar_meshset)
         stats[at_key] = get_stats(data[at_key])

--- a/generate_stats.py
+++ b/generate_stats.py
@@ -174,7 +174,7 @@ def collect_statistics(my_core, root_set, tar_meshset, display_options):
    
     if display_options['AT']:
         at_key = 'A_T'
-        data[at_key] = dagmc_stats.get_area_triangle(my_core, tar_meshset)
+        data[at_key] = dagmc_stats.get_area_triangle(my_core, tar_meshset, dagmc_tags['geom_dim'])
         stats[at_key] = get_stats(data[at_key])
 
     if display_options['SPV_data']:

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -106,4 +106,4 @@ def test_get_area_triangle():
     """
     a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)
     known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
-    assert(len(a_t_data) == known_triangles.size())	
+    assert(len(a_t_data) == known_triangles.size())

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -7,6 +7,7 @@ from pymoab.rng import Range
 # import the new module that defines each of the functions
 import dagmc_stats
 import nose
+import numpy as np
 
 test_input = "3vols.h5m"
 
@@ -78,16 +79,6 @@ def test_get_triangles_per_surface():
     triangles = my_core.get_entities_by_type(root_set, types.MBTRI).size()
     assert(sum(t_p_s_data) == triangles)
     
-
-def test_get_triangle_aspect_ratio():
-    """
-    Tests part of the get_triangle_aspect_ratio function
-    """
-    t_a_r_data = dagmc_stats.get_triangle_aspect_ratio(my_core, root_set)
-    known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
-    assert(len(t_a_r_data) == known_triangles.size())
-    
-    
 def test_get_surfaces_per_volume():
     """
     Tests different aspects of the get_surfaces_per_volume function
@@ -100,10 +91,32 @@ def test_get_surfaces_per_volume():
         surfs = my_core.get_child_meshsets(known_volumes[eh]).size()
         assert(surfs == s_p_v_data[eh])
 
+def test_get_triangle_aspect_ratio():
+    """
+    Tests part of the get_triangle_aspect_ratio function
+    """
+    test_input2 = "single-cube.h5m"
+    my_core = core.Core()
+    my_core.load_file(test_input2)
+    root_set = my_core.get_root_set()
+
+    assert(abs(dagmc_stats.get_triangle_aspect_ratio(my_core, root_set) - 1000*np.sqrt(2)/400/(10-5*np.sqrt(2))) < 0.01)
+
+    t_a_r_data = dagmc_stats.get_triangle_aspect_ratio(my_core, root_set)
+    known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
+    assert(len(t_a_r_data) == known_triangles.size())
+
 def test_get_area_triangle():
     """
     Tests part of the get__area_triangle function
     """
+    test_input2 = "single-cube.h5m"
+    my_core = core.Core()
+    my_core.load_file(test_input2)
+    root_set = my_core.get_root_set()
+
+    assert(get_area_triangle(my_core, root_set) == 5)
+
     a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)
     known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
     assert(len(a_t_data) == known_triangles.size())

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -99,3 +99,11 @@ def test_get_surfaces_per_volume():
     for eh in range(known_volumes.size()):
         surfs = my_core.get_child_meshsets(known_volumes[eh]).size()
         assert(surfs == s_p_v_data[eh])
+
+def test_get_area_triangle():
+	"""
+    Tests part of the get__area_triangle function
+    """
+    a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)
+    known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
+    assert(len(a_t_data) == known_triangles.size())

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -106,8 +106,8 @@ def test_get_triangle_aspect_ratio():
     obs = dagmc_stats.get_triangle_aspect_ratio(my_core, root_set)
     assertAlmostEqual(exp,obs)
     
-    exp = len(dagmc_stats.get_triangle_aspect_ratio(my_core, root_set))
-    obs = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    exp = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    obs = len(dagmc_stats.get_triangle_aspect_ratio(my_core, root_set))
     assertEqual(exp,obs)
 
 
@@ -124,6 +124,6 @@ def test_get_area_triangle():
     obs = get_area_triangle(my_core, root_set)
     assertEqual(exp,obs)
 
-    exp = len(dagmc_stats.get_area_triangle(my_core, root_set))
-    obs = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    exp = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    obs = len(dagmc_stats.get_area_triangle(my_core, root_set))
     assertEqual(exp,obs)

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -106,4 +106,4 @@ def test_get_area_triangle():
     """
     a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)
     known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
-    assert(len(a_t_data) == known_triangles.size())
+    assert(len(a_t_data) == known_triangles.size())	

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -25,7 +25,7 @@ def test_get_tags():
     dagmc_tags = dagmc_stats.get_dagmc_tags(my_core)
     assert(len(dagmc_tags) == 3)
 
-    
+
 def test_get_native_ranges():
     """
     Tests different aspects of the get_native_ranges function
@@ -38,7 +38,7 @@ def test_get_native_ranges():
     entityset_range = my_core.get_entities_by_type(root_set, types.MBENTITYSET)
     assert(entityset_range == native_ranges[11])
 
-    
+
 def test_get_entityset_ranges():
     """
     Tests different aspects of the get_entityset_ranges function
@@ -54,7 +54,7 @@ def test_get_entityset_ranges():
     volume_range = my_core.get_entities_by_type_and_tag(root_set, types.MBENTITYSET, dagmc_tags['geom_dim'], [3])
     assert(volume_range == entityset_ranges['Volumes'])
 
-    
+
 def test_get_triangles_per_vertex():
     "Tests part of the get_triangles_per_vertex function"
     dagmc_tags = dagmc_stats.get_dagmc_tags(my_core)
@@ -62,7 +62,7 @@ def test_get_triangles_per_vertex():
     t_p_v_data = dagmc_stats.get_triangles_per_vertex(my_core, native_ranges)
     vertices = my_core.get_entities_by_type(root_set, types.MBVERTEX).size()
     assert(len(t_p_v_data) == vertices)
-    
+
 
 def test_get_triangles_per_surface():
     """
@@ -78,7 +78,8 @@ def test_get_triangles_per_surface():
     assert(len(t_p_s_data) == surfaces)
     triangles = my_core.get_entities_by_type(root_set, types.MBTRI).size()
     assert(sum(t_p_s_data) == triangles)
-    
+
+
 def test_get_surfaces_per_volume():
     """
     Tests different aspects of the get_surfaces_per_volume function
@@ -91,6 +92,7 @@ def test_get_surfaces_per_volume():
         surfs = my_core.get_child_meshsets(known_volumes[eh]).size()
         assert(surfs == s_p_v_data[eh])
 
+
 def test_get_triangle_aspect_ratio():
     """
     Tests part of the get_triangle_aspect_ratio function
@@ -100,11 +102,14 @@ def test_get_triangle_aspect_ratio():
     my_core.load_file(test_input2)
     root_set = my_core.get_root_set()
 
-    assert(abs(dagmc_stats.get_triangle_aspect_ratio(my_core, root_set) - 1000*np.sqrt(2)/400/(10-5*np.sqrt(2))) < 0.01)
+    exp = 1000*np.sqrt(2)/400/(10-5*np.sqrt(2))
+    obs = dagmc_stats.get_triangle_aspect_ratio(my_core, root_set)
+    assertAlmostEqual(exp,obs)
+    
+    exp = len(dagmc_stats.get_triangle_aspect_ratio(my_core, root_set))
+    obs = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    assertEqual(exp,obs)
 
-    t_a_r_data = dagmc_stats.get_triangle_aspect_ratio(my_core, root_set)
-    known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
-    assert(len(t_a_r_data) == known_triangles.size())
 
 def test_get_area_triangle():
     """
@@ -115,8 +120,10 @@ def test_get_area_triangle():
     my_core.load_file(test_input2)
     root_set = my_core.get_root_set()
 
-    assert(get_area_triangle(my_core, root_set) == 5)
+    exp = 5
+    obs = get_area_triangle(my_core, root_set)
+    assertEqual(exp,obs)
 
-    a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)
-    known_triangles = my_core.get_entities_by_type(root_set, types.MBTRI)
-    assert(len(a_t_data) == known_triangles.size())
+    exp = len(dagmc_stats.get_area_triangle(my_core, root_set))
+    obs = my_core.get_entities_by_type(root_set, types.MBTRI).size()
+    assertEqual(exp,obs)

--- a/test_dagmc_stats.py
+++ b/test_dagmc_stats.py
@@ -101,7 +101,7 @@ def test_get_surfaces_per_volume():
         assert(surfs == s_p_v_data[eh])
 
 def test_get_area_triangle():
-	"""
+    """
     Tests part of the get__area_triangle function
     """
     a_t_data = dagmc_stats.get_area_triangle(my_core, root_set)


### PR DESCRIPTION
## Description
method for triangle area calculation in dagmc_stats.py file and its partial test

## Motivation and Context
calculate the areas of triangles

## Changes
In dagmc_stats.py: added function for triangle area calculation(get_area_triangle)
In generate_stats.py: added code to call the get_area_triangle function
In test_dagmc_stats.py: added partial test to test the get_area_triangle function. Tests if the number of areas generated is equal to the number of triangles.