### PR TITLE
More CI/testing updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,14 @@ jobs:
             - image: svalinn/pymoab-py3-18.04
         steps:
             - checkout
-            - run:  pip install -e . --user
             - run:
-                working_directory: tests/
                 command: pytest
     test_py2:
         docker:
             - image: svalinn/pymoab-py2-18.04
         steps:
             - checkout
-            - run:  pip install -e . --user
             - run:
-                working_directory: tests/
                 command: pytest
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
         steps:
             - checkout
             - run: pip install . --user
-            - run: python -c "import dagmc_stats"
+            - run:
+                working_directory: /home/root/
+                command: python -c "import dagmc_stats"
 
     install_py2:
         docker:
@@ -15,7 +17,9 @@ jobs:
         steps:
             - checkout
             - run: pip install . --user
-            - run: python -c "import dagmc_stats"
+            - run:
+                working_directory: /home/root/
+                command: python -c "import dagmc_stats"
 
     test_py3:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,24 @@
 version: 2.1
 
 jobs:
+    install_py3:
+        docker:
+            - image: svalinn/pymoab-py3-18.04
+        steps:
+            - checkout
+            - run:
+                command: pip install . --user
+                command: python -c "import dagmc_stats"
+
+    install_py2:
+        docker:
+            - image: svalinn/pymoab-py2-18.04
+        steps:
+            - checkout
+            - run:
+                command: pip install . --user
+                command: python -c "import dagmc_stats"
+
     test_py3:
         docker:
             - image: svalinn/pymoab-py3-18.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,16 @@ jobs:
             - image: svalinn/pymoab-py3-18.04
         steps:
             - checkout
-            - run:
-                command: pip install . --user
-                command: python -c "import dagmc_stats"
+            - run: pip install . --user
+            - run: python -c "import dagmc_stats"
 
     install_py2:
         docker:
             - image: svalinn/pymoab-py2-18.04
         steps:
             - checkout
-            - run:
-                command: pip install . --user
-                command: python -c "import dagmc_stats"
+            - run: pip install . --user
+            - run: python -c "import dagmc_stats"
 
     test_py3:
         docker:
@@ -37,5 +35,7 @@ jobs:
 workflows:
     build:
         jobs:
+            - install_py3
+            - install_py2
             - test_py3
             - test_py2

--- a/tests/test_dagmc_stats.py
+++ b/tests/test_dagmc_stats.py
@@ -7,7 +7,7 @@ import dagmc_stats.dagmc_stats as ds
 import numpy as np
 import unittest
 
-test_input = "3vols.h5m"
+test_input = "tests/3vols.h5m"
 
 my_core = core.Core()
 my_core.load_file(test_input)
@@ -104,7 +104,7 @@ class TestDagmcStats(unittest.TestCase):
         """
         Tests part of the get_triangle_aspect_ratio function
         """
-        test_input2 = "single-cube.h5m"
+        test_input2 = "tests/single-cube.h5m"
         my_core = core.Core()
         my_core.load_file(test_input2)
         root_set = my_core.get_root_set()
@@ -125,7 +125,7 @@ class TestDagmcStats(unittest.TestCase):
         """
         Tests part of the get__area_triangle function
         """
-        test_input2 = "single-cube.h5m"
+        test_input2 = "tests/single-cube.h5m"
         my_core = core.Core()
         my_core.load_file(test_input2)
         root_set = my_core.get_root_set()


### PR DESCRIPTION
As I am learning more and more about CI, testing, and pytest, I realized there are updates needed here. This PR does the following:
1. remove the pip install line from CI (unnecessary)
2. Changes the paths of the .h5m test files to be relative to the top level directory so that pytest can be run from the top level
3. runs pytest from the top level directory on CI
